### PR TITLE
fix: handle TooManyRequestsException

### DIFF
--- a/app/services/news_api/article.rb
+++ b/app/services/news_api/article.rb
@@ -4,8 +4,12 @@ class NewsApi::Article
   def self.get(params)
     default_params = {language: "en", sortBy: "relevancy"}
 
-    NewsApi::Request.get(params.merge(default_params)).each do |article|
-      article.id = SecureRandom.uuid
+    begin
+      NewsApi::Request.get(params.merge(default_params)).each do |article|
+        article.id = SecureRandom.uuid
+      end
+    rescue TooManyRequestsException
+      []
     end
   end
 end


### PR DESCRIPTION
return an empty response, and do not blow a 500 error